### PR TITLE
chore(ci): add initial GitHub Actions workflow for Maven build

### DIFF
--- a/.github/workflows/continuos-deployment.yml
+++ b/.github/workflows/continuos-deployment.yml
@@ -1,0 +1,24 @@
+name: Basic CI
+
+on:
+  pull_request:
+    branches: [ "main" ]
+  push:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Java 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+          cache: maven
+
+      - name: Build application
+        run: mvn clean package -DskipTests


### PR DESCRIPTION
- Created .github/workflows/ci.yml
- Configured Java 21 with Maven cache
- Set up step to build application with mvn clean package -DskipTests
- Workflow triggers on push and pull_request to main